### PR TITLE
邮件订阅刷新后订阅信息消失

### DIFF
--- a/index.js
+++ b/index.js
@@ -2467,6 +2467,10 @@ async function getConfig(env) {
       WECHATBOT_MSG_TYPE: config.WECHATBOT_MSG_TYPE || 'text',
       WECHATBOT_AT_MOBILES: config.WECHATBOT_AT_MOBILES || '',
       WECHATBOT_AT_ALL: config.WECHATBOT_AT_ALL || 'false',
+      RESEND_API_KEY: config.RESEND_API_KEY || '',
+      EMAIL_FROM: config.EMAIL_FROM || '',
+      EMAIL_FROM_NAME: config.EMAIL_FROM_NAME || '',
+      EMAIL_TO: config.EMAIL_TO || '',
       ENABLED_NOTIFIERS: config.ENABLED_NOTIFIERS || ['notifyx']
     };
 
@@ -2492,6 +2496,10 @@ async function getConfig(env) {
       WECHATBOT_MSG_TYPE: 'text',
       WECHATBOT_AT_MOBILES: '',
       WECHATBOT_AT_ALL: 'false',
+      RESEND_API_KEY: '',
+      EMAIL_FROM: '',
+      EMAIL_FROM_NAME: '',
+      EMAIL_TO: '',
       ENABLED_NOTIFIERS: ['notifyx']
     };
   }


### PR DESCRIPTION
修复以下Bug: https://github.com/wangwangit/SubsTracker/issues/27

- 邮件通知 配置中填写完邮件信息后点击测试邮件通知是可以正常收到邮件的，点击保存配置后刷新页面填写的邮件信息消失了
- 填写完邮件订阅信息后在订阅列表点击测试，此时无法正常收到邮件
- 查看kv数据库中此时的config中不存在配置的email信息
 