### PR TITLE
fix: 修正自定义webhook模版不生效的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -4461,9 +4461,11 @@ async function sendWebhookNotification(title, content, config) {
     if (config.WEBHOOK_TEMPLATE) {
       try {
         const template = JSON.parse(config.WEBHOOK_TEMPLATE);
+        title = JSON.stringify(title);
+        content = JSON.stringify(content);
         requestBody = JSON.stringify(template)
-          .replace(/\{\{title\}\}/g, title)
-          .replace(/\{\{content\}\}/g, content);
+          .replace(/\{\{title\}\}/g, title.slice(1, -1))
+          .replace(/\{\{content\}\}/g, content.slice(1, -1));
         requestBody = JSON.parse(requestBody);
       } catch (error) {
         console.warn('[企业微信应用通知] 消息模板格式错误，使用默认格式');


### PR DESCRIPTION
因为`content`字段字段中有`\n`等换行信息，替换`{{content}}`字段后再次`JSON.parse`会报错，然后逻辑总是会进入`catch`里面，导致webhook的自定义模版不生效。所以先把`content`字段通过`JSON.stringify`转化下，再次替换就ok了。