### PR TITLE
chore: 将 TailwindCSS 的 jsDelivr CDN 替换为 Cloudflare CDN

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ const loginPage = `
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>订阅管理系统</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
   <style>
     .login-container {
@@ -536,7 +536,7 @@ const adminPage = `
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>订阅管理系统</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
   <style>
     .btn-primary { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); transition: all 0.3s; }
@@ -3117,7 +3117,7 @@ const configPage = `
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>系统配置 - 订阅管理系统</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
   <style>
     .btn-primary { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); transition: all 0.3s; }


### PR DESCRIPTION
jsDelivr CDN 在中国访问不佳

<img width="1569" height="970" alt="www.itdog.cn jsDelivr CDN
网站测速" src="https://github.com/user-attachments/assets/a5924427-c59b-4c25-8322-9ffc0068ea0e" />

### 修改内容

将 TailwindCSS 的 jsDelivr CDN 替换为 Cloudflare CDN，以提升中国访问速度与稳定性。

### 具体改动

- 替换 `index.js`：
  - `https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css`
  - → `https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css`

### 提交信息

`chore: 将 TailwindCSS 的 jsDelivr CDN 替换为 Cloudflare CDN`

### 测试

本地验证页面样式正常加载，无其他影响。