### PR TITLE
农历数据转换及订阅币种同步问题修复

### DIFF
--- a/index.js
+++ b/index.js
@@ -2269,73 +2269,82 @@ const lunarBiz = {
         const periodUnit = subscription.periodUnit === 'day' ? '天' :
                           subscription.periodUnit === 'month' ? '月' : '年';
 
-        const modalHtml = \`
-            <div id="renewFormModal" class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50" onclick="closeRenewFormModal(event)">
-                <div class="relative top-20 mx-auto p-5 border w-full max-w-md shadow-lg rounded-md bg-white" onclick="event.stopPropagation()">
-                    <div class="flex justify-between items-center pb-3 border-b">
-                        <h3 class="text-xl font-semibold text-gray-900">
-                            <i class="fas fa-sync-alt mr-2"></i>手动续订 - \${subscription.name}
-                        </h3>
-                        <button onclick="closeRenewFormModal()" class="text-gray-400 hover:text-gray-500">
-                            <i class="fas fa-times text-2xl"></i>
-                        </button>
-                    </div>
+        // 获取动态货币符号
+        const currencySymbols = {
+          'CNY': '¥', 'USD': '$', 'HKD': 'HK$', 'TWD': 'NT$', 
+          'JPY': '¥', 'EUR': '€', 'GBP': '£', 'KRW': '₩'
+        };
+        const currency = subscription.currency || 'CNY';
+        const symbol = currencySymbols[currency] || '¥';
+        const currencyLabel = "(" + currency + " " + symbol + ")";
 
-                    <form id="renewForm" class="mt-4 space-y-4">
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1">支付日期</label>
-                            <input type="date" id="renewPaymentDate" value="\${today}"
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
-                        </div>
-
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1">支付金额 (¥)</label>
-                            <input type="number" id="renewAmount" value="\${defaultAmount}" step="0.01" min="0"
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
-                        </div>
-
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1">续订周期数</label>
-                            <div class="flex items-center space-x-2">
-                                <input type="number" id="renewPeriodMultiplier" value="1" min="1" max="120"
-                                       class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-                                       oninput="updateNewExpiryPreview()">
-                                <span class="text-gray-600">\${periodUnit}</span>
-                            </div>
-                            <p class="mt-1 text-xs text-gray-500">一次性续订多个周期（如12个月）</p>
-                        </div>
-
-                        <div class="bg-blue-50 rounded-lg p-3">
-                            <div class="flex justify-between text-sm mb-1">
-                                <span class="text-gray-600">当前到期:</span>
-                                <span class="font-medium">\${formattedExpiry}</span>
-                            </div>
-                            <div class="flex justify-between text-sm">
-                                <span class="text-gray-600">新到期日:</span>
-                                <span class="font-medium text-blue-600" id="newExpiryPreview">计算中...</span>
-                            </div>
-                        </div>
-
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 mb-1">备注 (可选)</label>
-                            <input type="text" id="renewNote" placeholder="例如：年度优惠、价格调整"
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
-                        </div>
-
-                        <div class="flex justify-end space-x-3 pt-3">
-                            <button type="button" onclick="closeRenewFormModal()"
-                                    class="px-4 py-2 bg-gray-500 hover:bg-gray-600 text-white rounded-md">
-                                取消
-                            </button>
-                            <button type="submit" id="confirmRenewBtn"
-                                    class="px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md">
-                                <i class="fas fa-check mr-1"></i>确认续订
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        \`;
+        // 【修复】使用单引号和 + 号拼接 HTML，避免反引号嵌套导致的语法错误
+        const modalHtml = 
+            '<div id="renewFormModal" class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50" onclick="closeRenewFormModal(event)">' +
+            '    <div class="relative top-20 mx-auto p-5 border w-full max-w-md shadow-lg rounded-md bg-white" onclick="event.stopPropagation()">' +
+            '        <div class="flex justify-between items-center pb-3 border-b">' +
+            '            <h3 class="text-xl font-semibold text-gray-900">' +
+            '                <i class="fas fa-sync-alt mr-2"></i>手动续订 - ' + subscription.name +
+            '            </h3>' +
+            '            <button onclick="closeRenewFormModal()" class="text-gray-400 hover:text-gray-500">' +
+            '                <i class="fas fa-times text-2xl"></i>' +
+            '            </button>' +
+            '        </div>' +
+            '' +
+            '        <form id="renewForm" class="mt-4 space-y-4">' +
+            '            <div>' +
+            '                <label class="block text-sm font-medium text-gray-700 mb-1">支付日期</label>' +
+            '                <input type="date" id="renewPaymentDate" value="' + today + '"' +
+            '                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">' +
+            '            </div>' +
+            '' +
+            '            <div>' +
+            '                <label class="block text-sm font-medium text-gray-700 mb-1">支付金额 ' + currencyLabel + '</label>' +
+            '                <input type="number" id="renewAmount" value="' + defaultAmount + '" step="0.01" min="0"' +
+            '                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">' +
+            '            </div>' +
+            '' +
+            '            <div>' +
+            '                <label class="block text-sm font-medium text-gray-700 mb-1">续订周期数</label>' +
+            '                <div class="flex items-center space-x-2">' +
+            '                    <input type="number" id="renewPeriodMultiplier" value="1" min="1" max="120"' +
+            '                           class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"' +
+            '                           oninput="updateNewExpiryPreview()">' +
+            '                    <span class="text-gray-600">' + periodUnit + '</span>' +
+            '                </div>' +
+            '                <p class="mt-1 text-xs text-gray-500">一次性续订多个周期（如12个月）</p>' +
+            '            </div>' +
+            '' +
+            '            <div class="bg-blue-50 rounded-lg p-3">' +
+            '                <div class="flex justify-between text-sm mb-1">' +
+            '                    <span class="text-gray-600">当前到期:</span>' +
+            '                    <span class="font-medium">' + formattedExpiry + '</span>' +
+            '                </div>' +
+            '                <div class="flex justify-between text-sm">' +
+            '                    <span class="text-gray-600">新到期日:</span>' +
+            '                    <span class="font-medium text-blue-600" id="newExpiryPreview">计算中...</span>' +
+            '                </div>' +
+            '            </div>' +
+            '' +
+            '            <div>' +
+            '                <label class="block text-sm font-medium text-gray-700 mb-1">备注 (可选)</label>' +
+            '                <input type="text" id="renewNote" placeholder="例如：年度优惠、价格调整"' +
+            '                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">' +
+            '            </div>' +
+            '' +
+            '            <div class="flex justify-end space-x-3 pt-3">' +
+            '                <button type="button" onclick="closeRenewFormModal()"' +
+            '                        class="px-4 py-2 bg-gray-500 hover:bg-gray-600 text-white rounded-md">' +
+            '                    取消' +
+            '                </button>' +
+            '                <button type="submit" id="confirmRenewBtn"' +
+            '                        class="px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md">' +
+            '                    <i class="fas fa-check mr-1"></i>确认续订' +
+            '                </button>' +
+            '            </div>' +
+            '        </form>' +
+            '    </div>' +
+            '</div>';
 
         document.body.insertAdjacentHTML('beforeend', modalHtml);
 
@@ -7219,12 +7228,12 @@ function getExpenseByType(subscriptions, timezone) {
   });
 
   return Object.entries(typeMap)
-    。map(([type, amount]) => ({
+    .map(([type, amount]) => ({
       type,
       amount,
       percentage: total > 0 ? Math.round((amount / total) * 100) : 0
     }))
-    。sort((a, b) => b.amount - a.amount);
+    .sort((a, b) => b.amount - a.amount);
 }
 
 function getExpenseByCategory(subscriptions, timezone) {
@@ -7258,10 +7267,10 @@ function getExpenseByCategory(subscriptions, timezone) {
   });
 
   return Object.entries(categoryMap)
-    。map(([category, amount]) => ({
+    .map(([category, amount]) => ({
       category,
       amount,
       percentage: total > 0 ? Math.round((amount / total) * 100) : 0
     }))
-    。sort((a, b) => b.amount - a.amount);
+    .sort((a, b) => b.amount - a.amount);
 }


### PR DESCRIPTION
### **解决的问题点:**

### **修复1.**

**修复公历日期与农历日期相差1天的问题。**

问题1：solar2lunar函数使用new Date()来创建日期对象，产生偏移量。

修复方案：使用Date.UTC() 方法来构造日期，强制使用UTC时间戳进行计算。



### **修复2.**

**修复2025至2099年期间农历日期偏差问题。**

问题2：lunarInfo数组中部分年份的十六进制数据存在错误或遗漏闰月信息，导致solar2lunar计算时的总天数出现偏移量。

修复方案：经过完全修正和验证的lunarInfo数组，替换index.js中原有的lunarInfo数组。



**【验证方法】使用以下4个特殊日期进行验证**

【0.测试日期：2033-08-25】

**正确农历： 癸丑年八月初一**

测试结果：显示正确的农历：癸丑年八月初一 （计算结果：正确）


【1.测试日期： 2052-10-01 (国庆节)】

**正确农历： 壬申年 闰八月初九**

测试结果：显示正确的农历：壬申年闰八月初九 （计算结果：正确）


【2.测试日期： 2062-02-08】

**正确农历： 辛丑年 腊月 二十九 （除夕**）

测试结果：显示正确的农历：辛巳年腊月廿九 （计算结果：正确）


【3.测试日期： 2099-12-31】

**正确农历： 己未年 冬月 二十**

测试结果：显示正确的农历：己未年冬月二十（计算结果：正确）

<img width="1312" height="597" alt="20260112-1" src="https://github.com/user-attachments/assets/fd347afd-ba22-4a38-8e0c-739b10aed198" />
<img width="1291" height="629" alt="20260112-2" src="https://github.com/user-attachments/assets/d165d975-fe44-436e-828b-ef52f988bd63" />


### 修复3.

**修复“手动续订”与“订阅列表”币种符号不同步问题。**

问题3：在showRenewFormModal函数中，硬编码默认写死了(¥)，没有根据订阅信息中的currency字段动态显示对应的货币符号。

修复方案：修正currency字段，动态显示对应的货币符号。