### PR TITLE
fix(admin): 修复订阅列表农历显示开关无效

### DIFF
--- a/src/views/adminPage.html
+++ b/src/views/adminPage.html
@@ -1899,6 +1899,11 @@ const lunarBiz = {
       statusSelect.addEventListener('change', () => renderSubscriptionTable());
     }
 
+    const listShowLunar = document.getElementById('listShowLunar');
+    if (listShowLunar) {
+      listShowLunar.addEventListener('change', handleListLunarToggle);
+    }
+
     // 获取所有订阅并按到期时间排序
     async function loadSubscriptions(showLoading = true) {
       try {

--- a/tests/views/admin-page.test.js
+++ b/tests/views/admin-page.test.js
@@ -1,0 +1,11 @@
+// @ts-check
+import { describe, expect, it } from 'vitest';
+import adminPage from '../../src/views/adminPage.html';
+
+describe('admin page subscription list', () => {
+  it('re-renders the subscription table when the lunar display checkbox changes', () => {
+    expect(adminPage).toMatch(
+      /listShowLunar\.addEventListener\(['"]change['"],\s*handleListLunarToggle\)/
+    );
+  });
+});


### PR DESCRIPTION
  - 为农历显示复选框绑定 change 事件，切换后立即重新渲染订阅列表
  - 添加管理页回归测试，防止事件绑定再次丢失                                                                                                                                                                               

[20260715_111936_recording.webm](https://github.com/user-attachments/assets/b2ade369-1a6a-484b-98bb-b49f664df613)


close #193 