### PR TITLE
fix: 解析 wrangler stdout 时忽略代理提示行，避免 setup 失败

### DIFF
--- a/scripts/setup-kv.cjs
+++ b/scripts/setup-kv.cjs
@@ -18,7 +18,8 @@ function run(command) {
 
 function listNamespaces() {
   const output = run('npx wrangler kv namespace list');
-  const parsed = JSON.parse(output);
+  const start = output.indexOf('[');
+  const parsed = start === -1 ? [] : JSON.parse(output.slice(start));
   return Array.isArray(parsed) ? parsed : [];
 }
 


### PR DESCRIPTION
## 问题

当本机设置了代理环境变量（`http_proxy`/`https_proxy`/`all_proxy`）时，wrangler 会在 stdout 打印一行提示：

```
Proxy environment variables detected. We'll use your proxy for fetch requests.
```

`scripts/setup-kv.cjs` 的 `listNamespaces()` 直接对整段 stdout 执行 `JSON.parse`，把这一行当成 JSON 的一部分，导致 `npm run deploy:safe` 报错：

```
[setup-kv] 失败: Unexpected token 'P', "Proxy envi"... is not valid JSON
```

## 修复

只解析 stdout 中第一个 `[` 之后的内容，忽略前导的提示行。若无 `[` 则返回空数组。

## 验证

`npm run deploy:safe` 在设置代理后正常通过并成功部署。